### PR TITLE
fixed #6 app shell MaterialApp not rebuilding when language is changed/set

### DIFF
--- a/git_explorer_mob/lib/app/app_shell.dart
+++ b/git_explorer_mob/lib/app/app_shell.dart
@@ -73,7 +73,8 @@ class _AppShellState extends ConsumerState<AppShell> {
 
     return MaterialApp(
       debugShowCheckedModeBanner: false,
-      locale: Prefs().locale,
+      // Use the watched prefs instance so MaterialApp rebuilds when locale changes.
+      locale: prefs.locale,
       localizationsDelegates: L10n.localizationsDelegates,
       supportedLocales: L10n.supportedLocales,
       title: 'Git Explorer',


### PR DESCRIPTION
Replaced Prefs to watch the prefsProvider to rebuild whenever the saveLocalToPrefs changes, it rebuilds the MaterialApp widget instantly